### PR TITLE
Don't verify SSL connections when retrieving remote resources

### DIFF
--- a/src/SimplyTestable/WorkerBundle/Services/HttpClientService.php
+++ b/src/SimplyTestable/WorkerBundle/Services/HttpClientService.php
@@ -66,6 +66,9 @@ class HttpClientService
             'config' => [
                 'curl' => $this->curlOptions
             ],
+            'defaults' => [
+                'verify' => false,
+            ],
         ]);
 
         $cacheSubscriber = $this->createCacheSubscriber();


### PR DESCRIPTION
Possibly a bad choice, but it often happens that remote servers are incorrectly configured.