### PR TITLE
Rename examiner::perform() -> examine()

### DIFF
--- a/src/Services/TaskExaminer/WebPageTask/ContentEncodingExaminer.php
+++ b/src/Services/TaskExaminer/WebPageTask/ContentEncodingExaminer.php
@@ -25,10 +25,10 @@ class ContentEncodingExaminer
 
     public function __invoke(TaskEvent $taskEvent)
     {
-        $this->perform($taskEvent->getTask());
+        $this->examine($taskEvent->getTask());
     }
 
-    public function perform(Task $task)
+    public function examine(Task $task)
     {
         $webPage = $this->taskCachedSourceWebPageRetriever->retrieve($task);
 

--- a/src/Services/TaskExaminer/WebPageTask/FailedSourceExaminer.php
+++ b/src/Services/TaskExaminer/WebPageTask/FailedSourceExaminer.php
@@ -20,10 +20,10 @@ class FailedSourceExaminer
 
     public function __invoke(TaskEvent $taskEvent)
     {
-        $this->perform($taskEvent->getTask());
+        $this->examine($taskEvent->getTask());
     }
 
-    public function perform(Task $task)
+    public function examine(Task $task)
     {
         $sources = $task->getSources();
         /* @var Source $primarySource */

--- a/src/Services/TaskExaminer/WebPageTask/InvalidSourceExaminer.php
+++ b/src/Services/TaskExaminer/WebPageTask/InvalidSourceExaminer.php
@@ -21,10 +21,10 @@ class InvalidSourceExaminer
 
     public function __invoke(TaskEvent $taskEvent)
     {
-        $this->perform($taskEvent->getTask());
+        $this->examine($taskEvent->getTask());
     }
 
-    public function perform(Task $task)
+    public function examine(Task $task)
     {
         $sources = $task->getSources();
         /* @var Source $primarySource */

--- a/tests/Functional/Services/TaskExaminer/WebPageTask/WebPageTaskContentEncodingExaminerTest.php
+++ b/tests/Functional/Services/TaskExaminer/WebPageTask/WebPageTaskContentEncodingExaminerTest.php
@@ -31,9 +31,9 @@ class WebPageTaskContentEncodingExaminerTest extends AbstractBaseTestCase
     }
 
     /**
-     * @dataProvider performNoChangesDataProvider
+     * @dataProvider examineNoChangesDataProvider
      */
-    public function testPerformNoChanges(callable $webPageCreator)
+    public function testExamineNoChanges(callable $webPageCreator)
     {
         $webPage = $webPageCreator();
 
@@ -58,13 +58,13 @@ class WebPageTaskContentEncodingExaminerTest extends AbstractBaseTestCase
 
         $taskState = $task->getState();
 
-        $this->examiner->perform($task);
+        $this->examiner->examine($task);
 
         $this->assertEquals($taskState, $task->getState());
         $this->assertNull($task->getOutput());
     }
 
-    public function performNoChangesDataProvider()
+    public function examineNoChangesDataProvider()
     {
         return [
             'task has no web page primary source' => [
@@ -86,9 +86,9 @@ class WebPageTaskContentEncodingExaminerTest extends AbstractBaseTestCase
     }
 
     /**
-     * @dataProvider performSetsTaskAsFailedDataProvider
+     * @dataProvider examineSetsTaskAsFailedDataProvider
      */
-    public function testPerformSetsTaskAsFailed(callable $webPageCreator, string $expectedCharacterSetInOutput)
+    public function testExamineSetsTaskAsFailed(callable $webPageCreator, string $expectedCharacterSetInOutput)
     {
         /* @var WebPage $webPage */
         $webPage = $webPageCreator();
@@ -112,7 +112,7 @@ class WebPageTaskContentEncodingExaminerTest extends AbstractBaseTestCase
             $taskCachedResourceWebPageRetriever
         );
 
-        $this->examiner->perform($task);
+        $this->examiner->examine($task);
 
         $this->assertEquals(Task::STATE_FAILED_NO_RETRY_AVAILABLE, $task->getState());
 
@@ -131,7 +131,7 @@ class WebPageTaskContentEncodingExaminerTest extends AbstractBaseTestCase
         ]), $taskOutput->getOutput());
     }
 
-    public function performSetsTaskAsFailedDataProvider()
+    public function examineSetsTaskAsFailedDataProvider()
     {
         return [
             'Invalid two-octet sequence with no specific encoding' => [

--- a/tests/Functional/Services/TaskExaminer/WebPageTask/WebPageTaskFailedSourceExaminerTest.php
+++ b/tests/Functional/Services/TaskExaminer/WebPageTask/WebPageTaskFailedSourceExaminerTest.php
@@ -27,24 +27,24 @@ class WebPageTaskFailedSourceExaminerTest extends AbstractBaseTestCase
     }
 
     /**
-     * @dataProvider performNoChangesDataProvider
+     * @dataProvider examineNoChangesDataProvider
      *
      * @param callable $taskCreator
      */
-    public function testPerformNoChanges(callable $taskCreator)
+    public function testExamineNoChanges(callable $taskCreator)
     {
         /* @var Task $task */
         $task = $taskCreator();
 
         $taskState = $task->getState();
 
-        $this->examiner->perform($task);
+        $this->examiner->examine($task);
 
         $this->assertEquals($taskState, $task->getState());
         $this->assertNull($task->getOutput());
     }
 
-    public function performNoChangesDataProvider()
+    public function examineNoChangesDataProvider()
     {
         return [
             'no sources' => [
@@ -107,12 +107,12 @@ class WebPageTaskFailedSourceExaminerTest extends AbstractBaseTestCase
     }
 
     /**
-     * @dataProvider performSetsTaskAsFailedDataProvider
+     * @dataProvider examineSetsTaskAsFailedDataProvider
      *
      * @param callable $taskCreator
      * @param array $expectedOutput
      */
-    public function testPerformSetsTaskAsFailed(callable $taskCreator, array $expectedOutput)
+    public function testExamineSetsTaskAsFailed(callable $taskCreator, array $expectedOutput)
     {
         /* @var Task $task */
         $task = $taskCreator();
@@ -120,7 +120,7 @@ class WebPageTaskFailedSourceExaminerTest extends AbstractBaseTestCase
         $this->assertEquals(Task::STATE_QUEUED, $task->getState());
         $this->assertNull($task->getOutput());
 
-        $this->examiner->perform($task);
+        $this->examiner->examine($task);
 
         $this->assertEquals(Task::STATE_FAILED_NO_RETRY_AVAILABLE, $task->getState());
 
@@ -131,7 +131,7 @@ class WebPageTaskFailedSourceExaminerTest extends AbstractBaseTestCase
         $this->assertEquals(json_encode($expectedOutput), $taskOutput->getOutput());
     }
 
-    public function performSetsTaskAsFailedDataProvider()
+    public function examineSetsTaskAsFailedDataProvider()
     {
         return [
             'redirect loop' => [

--- a/tests/Functional/Services/TaskExaminer/WebPageTask/WebPageTaskInvalidSourceExaminerTest.php
+++ b/tests/Functional/Services/TaskExaminer/WebPageTask/WebPageTaskInvalidSourceExaminerTest.php
@@ -29,24 +29,24 @@ class WebPageTaskInvalidSourceExaminerTest extends AbstractBaseTestCase
     }
 
     /**
-     * @dataProvider performNoChangesDataProvider
+     * @dataProvider examineNoChangesDataProvider
      *
      * @param callable $taskCreator
      */
-    public function testPerformNoChanges(callable $taskCreator)
+    public function testExamineNoChanges(callable $taskCreator)
     {
         /* @var Task $task */
         $task = $taskCreator();
 
         $taskState = $task->getState();
 
-        $this->examiner->perform($task);
+        $this->examiner->examine($task);
 
         $this->assertEquals($taskState, $task->getState());
         $this->assertNull($task->getOutput());
     }
 
-    public function performNoChangesDataProvider()
+    public function examineNoChangesDataProvider()
     {
         return [
             'no sources' => [
@@ -107,11 +107,11 @@ class WebPageTaskInvalidSourceExaminerTest extends AbstractBaseTestCase
     }
 
     /**
-     * @dataProvider performSetsTaskAsSkippedDataProvider
+     * @dataProvider examineSetsTaskAsSkippedDataProvider
      *
      * @param callable $taskCreator
      */
-    public function testPerformSetsTaskAsSkipped(callable $taskCreator)
+    public function testExamineSetsTaskAsSkipped(callable $taskCreator)
     {
         $testTaskFactory = self::$container->get(TestTaskFactory::class);
         $sourceFactory = self::$container->get(SourceFactory::class);
@@ -124,7 +124,7 @@ class WebPageTaskInvalidSourceExaminerTest extends AbstractBaseTestCase
         $this->assertEquals(Task::STATE_QUEUED, $task->getState());
         $this->assertNull($task->getOutput());
 
-        $this->examiner->perform($task);
+        $this->examiner->examine($task);
 
         $this->assertEquals(Task::STATE_SKIPPED, $task->getState());
 
@@ -135,7 +135,7 @@ class WebPageTaskInvalidSourceExaminerTest extends AbstractBaseTestCase
         $this->assertEquals('', $taskOutput->getOutput());
     }
 
-    public function performSetsTaskAsSkippedDataProvider()
+    public function examineSetsTaskAsSkippedDataProvider()
     {
         return [
             'invalid primary source, is invalid content type' => [


### PR DESCRIPTION
Fixes #454